### PR TITLE
ci: move Linux CI to self-hosted ARC (sized -4/-8)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+self-hosted-runner:
+  # Self-hosted ARC runner labels (Actions Runner Controller on ever-k8s).
+  labels:
+    - ever-k8s-linux-x64-4
+    - ever-k8s-linux-x64-8

--- a/.github/workflows/jenkins-image.yml
+++ b/.github/workflows/jenkins-image.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   jenkins:
-    runs-on: ever-k8s-linux-x64-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/jenkins-image.yml
+++ b/.github/workflows/jenkins-image.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   jenkins:
-    runs-on: ubuntu-latest
+    runs-on: ever-k8s-linux-x64-4
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/sonarqube-image.yml
+++ b/.github/workflows/sonarqube-image.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   sonarqube:
-    runs-on: ever-k8s-linux-x64-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/sonarqube-image.yml
+++ b/.github/workflows/sonarqube-image.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   sonarqube:
-    runs-on: ubuntu-latest
+    runs-on: ever-k8s-linux-x64-4
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
## Move Linux CI to sized self-hosted ARC runners

Migrates cloud Linux CI in this repo to sized self-hosted ARC labels running on the `ever-k8s` cluster (Actions Runner Controller on `k8s-w1..w5`).

### Runner mapping applied
| Old (cloud) | New (self-hosted ARC) |
| --- | --- |
| `ubuntu-latest` | `ever-k8s-linux-x64-4` |

### Jobs migrated
- **-4 (`ever-k8s-linux-x64-4`): 2 jobs**
  - `.github/workflows/jenkins-image.yml` -> job `jenkins`
  - `.github/workflows/sonarqube-image.yml` -> job `sonarqube`
- **-8 (`ever-k8s-linux-x64-8`): 0 jobs**

### actionlint
- Added `.github/actionlint.yaml` declaring both self-hosted labels (`ever-k8s-linux-x64-4`, `ever-k8s-linux-x64-8`) under `self-hosted-runner.labels` so actionlint does not flag the custom runners.

### Left on GitHub-hosted / unchanged (intentional)
- **CodeQL** jobs (`github/codeql-action`) — none present in this repo; policy is CodeQL stays GitHub-hosted.
- **macOS**, **Windows** runners.
- **ARM** runners (`*-arm`, `ubicloud-standard-8-arm`).
- **16-core** runners (`ubuntu-latest-16-cores`).
- Fork-PR CI remains disabled (self-hosted runners are not exposed to fork PRs).

Reviewable PR only — do not merge until the ARC runner pools are confirmed healthy.